### PR TITLE
Upgrading to 1.5.2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,8 +14,8 @@ RUN apt-get -y install software-properties-common && \
 
 # Install Elasticsearch and clean up
 RUN apt-get -y install wget && cd /tmp && \
-    wget http://bit.ly/elasticsearch-132 && tar xvzf elasticsearch-132 && \
-    mv /tmp/elasticsearch-1.3.2 /elasticsearch && rm -rf elasticsearch-132
+    wget http://bit.ly/elasticsearch-152 && tar xvzf elasticsearch-152 && \
+    mv /tmp/elasticsearch-1.5.2 /elasticsearch && rm -rf elasticsearch-152
 
 # Mount elasticsearch.yml config
 ADD templates/elasticsearch.yml /elasticsearch/config/elasticsearch.yml

--- a/templates/elasticsearch.yml
+++ b/templates/elasticsearch.yml
@@ -3,3 +3,5 @@ path:
   logs: /data/log
   plugins: /data/plugins
   work: /data/work
+http.cors.enabled: true
+http.cors.allow-origin: "/.*/"

--- a/templates/nginx.conf
+++ b/templates/nginx.conf
@@ -43,6 +43,7 @@ http {
     location / {
       proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
       proxy_set_header Host $http_host;
+      add_header 'Access-Control-Allow-Credentials' 'true';
       proxy_redirect off;
 
       proxy_pass http://containers;

--- a/test/elasticsearch.bats
+++ b/test/elasticsearch.bats
@@ -1,8 +1,8 @@
 #!/usr/bin/env bats
 
-@test "It should install Elasticsearch 1.3.2" {
+@test "It should install Elasticsearch 1.5.2" {
   run /elasticsearch/bin/elasticsearch -v
-  [[ "$output" =~ "Version: 1.3.2"  ]]
+  [[ "$output" =~ "Version: 1.5.2"  ]]
 }
 
 wait_for_elasticsearch() {

--- a/test/elasticsearch.bats
+++ b/test/elasticsearch.bats
@@ -11,7 +11,7 @@ wait_for_elasticsearch() {
 }
 
 teardown() {
-  PID=$(pgrep java)
+  PID=$(pgrep java) || return 0
   run pkill java
   run pkill nginx
   while [ -n "$PID" ] && [ -e /proc/$PID ]; do sleep 0.1; done


### PR DESCRIPTION
I tested this as best I could with the Kibana 3 docker-kibana image and it seemed to work fine.

Because I don't have the VHOST setup that you guys have, the redirect to https in the docker image had to be turned off locally while I tested, and I had to manually add the elasticsearch url in the config.js file of the docker-kibana image. So I highly suggest testing it with your VHOST setup using the Kibana 3 docker-kibana image.

I also upgraded the docker-kibana image to Kibana 4 (https://github.com/aptible/docker-kibana/pull/6). Once again, the redirect to https needed to be turned off locally. Kibana 4 is much different than Kibana 3 in that it is a java applet, not just static html and js files. So once again, I would definitely suggest testing with your setup once the docker-kibana image is updated to version 4.