### PR TITLE
Disable Elasticsearch's zen multicast discovery.

### DIFF
--- a/templates/elasticsearch.yml
+++ b/templates/elasticsearch.yml
@@ -1,5 +1,7 @@
+discovery.zen.ping.multicast.enabled: false
 path:
   data: /data/data
   logs: /data/log
   plugins: /data/plugins
   work: /data/work
+


### PR DESCRIPTION
When multicast discovery is on, an instance will send UDP ping packets and discover other instances within the cluster on the same subnet. Since we don't name our clusters to differentiate them among containers, we want to turn this off to avoid Elasticsearch instances on the same subnet creating a cluster together.