### PR TITLE
Add dump/restore/readonly functionality

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,19 +18,28 @@ RUN apt-get -y install wget && cd /tmp && \
     wget http://bit.ly/elasticsearch-152 && tar xvzf elasticsearch-152 && \
     mv /tmp/elasticsearch-1.5.2 /elasticsearch && rm -rf elasticsearch-152
 
-# Mount elasticsearch.yml config
-ADD templates/elasticsearch.yml /elasticsearch/config/elasticsearch.yml
-
 # Install NGiNX
 RUN add-apt-repository -y ppa:nginx/stable && apt-get update && \
     apt-get -y install nginx && mkdir -p /etc/nginx/ssl
-ADD templates/nginx.conf /etc/nginx/nginx.conf
-ADD templates/nginx-wrapper /usr/sbin/nginx-wrapper
 
 # Install htpasswd for HTTP Basic Auth
 RUN apt-get -y install apache2-utils
 
+# Install node.js and elasticdump tool for --dump/--restore options.
+# https://github.com/taskrabbit/elasticsearch-dump
+RUN wget -q -O - http://nodejs.org/dist/v0.12.4/node-v0.12.4-linux-x64.tar.gz | tar zxf - && \
+    ln -s /node-v0.12.4-linux-x64/bin/node /usr/local/bin/ && \
+    ln -s /node-v0.12.4-linux-x64/bin/npm /usr/local/bin/ && \
+    npm install -g elasticdump
+
+ADD templates/nginx.conf /etc/nginx/nginx.conf
+ADD templates/nginx-wrapper /usr/sbin/nginx-wrapper
+
+# Mount elasticsearch.yml config
+ADD templates/elasticsearch.yml /elasticsearch/config/elasticsearch.yml
+
 ADD run-database.sh /usr/bin/
+ADD utilities.sh /usr/bin/
 
 # Integration tests
 ADD test /tmp/test

--- a/run-database.sh
+++ b/run-database.sh
@@ -1,8 +1,28 @@
 #!/bin/bash
 
+. /usr/bin/utilities.sh
+
 if [[ "$1" == "--initialize" ]]; then
   htpasswd -b -c "$DATA_DIRECTORY"/auth_basic.htpasswd "${USERNAME:-aptible}" "$PASSPHRASE"
   exit
-fi
 
-/usr/sbin/nginx-wrapper
+elif [[ "$1" == "--client" ]]; then
+  echo "This image does not support the --client option. Use curl instead." && exit 1
+
+elif [[ "$1" == "--dump" ]]; then
+  [ -z "$2" ] && echo "docker run aptible/elasticsearch --dump http://... > dump.es" && exit
+  parse_url "$2"
+  elasticdump --all=true --input="http://"$user":"$password"@"$host":"${port:-80}"" --output=$
+
+elif [[ "$1" == "--restore" ]]; then
+  [ -z "$2" ] && echo "docker run -i aptible/elasticsearch --restore http://... < dump.es" && exit
+  parse_url "$2"
+  elasticdump --bulk=true --input=$ --output="http://"$user":"$password"@"$host":"${port:-80}""
+
+elif [[ "$1" == "--readonly" ]]; then
+  READONLY=1 /usr/sbin/nginx-wrapper
+
+else
+  /usr/sbin/nginx-wrapper
+
+fi

--- a/templates/nginx-wrapper
+++ b/templates/nginx-wrapper
@@ -14,5 +14,9 @@ if [ -f "$AUTH_FILE" ]; then
   sed -i 's/\# auth_basic/auth_basic/' /etc/nginx/nginx.conf
 fi
 
+if [ -n "$READONLY" ]; then
+  sed -i 's/\#RO //g' /etc/nginx/nginx.conf
+fi
+
 /elasticsearch/bin/elasticsearch &
 /usr/sbin/nginx $@

--- a/templates/nginx.conf
+++ b/templates/nginx.conf
@@ -41,7 +41,7 @@ http {
     keepalive_timeout 5;
 
     location / {
-      #RO if ($request_method !~ "GET") {
+      #RO if ($request_method !~* ^GET$|^OPTIONS$|^HEAD$) {
       #RO   return 403;
       #RO   break;
       #RO }
@@ -66,7 +66,7 @@ http {
     keepalive_timeout 5;
 
     location / {
-      #RO if ($request_method !~ "GET") {
+      #RO if ($request_method !~* ^GET$|^OPTIONS$|^HEAD$) {
       #RO   return 403;
       #RO   break;
       #RO }

--- a/templates/nginx.conf
+++ b/templates/nginx.conf
@@ -41,6 +41,11 @@ http {
     keepalive_timeout 5;
 
     location / {
+      #RO if ($request_method !~ "GET") {
+      #RO   return 403;
+      #RO   break;
+      #RO }
+
       proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
       proxy_set_header Host $http_host;
       add_header 'Access-Control-Allow-Credentials' 'true';
@@ -61,6 +66,11 @@ http {
     keepalive_timeout 5;
 
     location / {
+      #RO if ($request_method !~ "GET") {
+      #RO   return 403;
+      #RO   break;
+      #RO }
+
       proxy_set_header X-Forwarded-Proto https;
       proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
       proxy_set_header Host $http_host;

--- a/utilities.sh
+++ b/utilities.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+
+parse_url()
+{
+  # cf http://stackoverflow.com/a/17287984
+  protocol="$(echo "$1" | grep :// | sed -e's,^\(.*://\).*,\1,g')"
+  # remove the protocol
+  url=$(echo $1 | sed -e s,$protocol,,g)
+  # extract the user and password (if any)
+  user_and_password="$(echo $url | grep @ | cut -d@ -f1)"
+  password="$(echo $user_and_password | grep : | cut -d: -f2)"
+  if [ -n "$password" ]; then
+    user="$(echo $user_and_password | grep : | cut -d: -f1)"
+  else
+    user="$user_and_password"
+  fi
+
+  # extract the host
+  host_and_port="$(echo $url | sed -e s,$user_and_password@,,g | cut -d/ -f1)"
+  port="$(echo $host_and_port | grep : | cut -d: -f2)"
+  if [ -n "$port" ]; then
+    host="$(echo $host_and_port | grep : | cut -d: -f1)"
+  else
+    host="$host_and_port"
+  fi
+
+  database="$(echo $url | grep / | cut -d/ -f2-)"
+}


### PR DESCRIPTION
Notes:

* ElasticSearch doesn't seem to have built-in support for "dump to stdout/restore from stdin", so this image uses the [elasticdump](https://github.com/taskrabbit/elasticsearch-dump) tool to make that happen.
* ElasticSearch doesn't seem to have built-in support for a read-only mode. The accepted ways to enable read-only mode are (1) a plugin [readonlyrest](https://github.com/sscarduzio/elasticsearch-readonlyrest-plugin), and (2) proxying through nginx and only allowing `GET` requests. I went with the latter (I also tried the plugin but couldn't get it set up correctly).