### PR TITLE
Install cloud-aws plugin, source plugins from Docker image instead of data directory

### DIFF
--- a/1.5/Dockerfile
+++ b/1.5/Dockerfile
@@ -18,6 +18,10 @@ RUN apt-get -y install wget && cd /tmp && \
     wget http://bit.ly/elasticsearch-152 && tar xvzf elasticsearch-152 && \
     mv /tmp/elasticsearch-1.5.2 /elasticsearch && rm -rf elasticsearch-152
 
+# Install plugins. Note that these versions are tied to the Elasticsearch server
+# version and should change when the server version is upgraded.
+RUN /elasticsearch/bin/plugin install elasticsearch/elasticsearch-cloud-aws/2.5.1
+
 # Install NGiNX
 RUN add-apt-repository -y ppa:nginx/stable && apt-get update && \
     apt-get -y install nginx && mkdir -p /etc/nginx/ssl

--- a/1.5/templates/elasticsearch.yml
+++ b/1.5/templates/elasticsearch.yml
@@ -2,7 +2,7 @@ discovery.zen.ping.multicast.enabled: false
 path:
   data: /var/db/data
   logs: /var/db/log
-  plugins: /var/db/plugins
+  plugins: /elasticsearch/plugins
   work: /var/db/work
 http.cors.enabled: true
 http.cors.allow-origin: "/.*/"

--- a/1.5/test/elasticsearch.bats
+++ b/1.5/test/elasticsearch.bats
@@ -55,3 +55,7 @@ teardown() {
   run timeout 5 /elasticsearch/bin/elasticsearch -Des.logger.discovery=TRACE
   ! [[ "$output" =~ "sending ping request" ]]
 }
+
+@test "It should have the cloud-aws plugin installed" {
+  /elasticsearch/bin/plugin --list | grep -q "cloud-aws"
+}


### PR DESCRIPTION
Elasticsearch plugins need to be installed with the `bin/plugin` tool, which isn't externally accessible in this image (i.e., there's no way to run it right now with the run-database.sh entrypoint). If/until we do support adding plugins, I think it makes sense to just bake whatever we need into the Docker image.

This patch adds the cloud-aws plugin, which enables easy backups to S3 with scripts like https://github.com/aptible/elasticsearch-logstash-s3-backup.