### PR TITLE
WIP - Add support for ElasticSearch Clustering

### DIFF
--- a/1.5/Dockerfile
+++ b/1.5/Dockerfile
@@ -37,12 +37,16 @@ RUN wget -q -O - http://nodejs.org/dist/v0.12.4/node-v0.12.4-linux-x64.tar.gz | 
     ln -s /node-v0.12.4-linux-x64/bin/npm /usr/local/bin/ && \
     npm install -g elasticdump
 
+# Curl it curl it
+RUN apt-install -y curl pwgen python
+
 ADD templates/nginx.conf.template /etc/nginx/nginx.conf.template
 ADD templates/nginx-wrapper /usr/sbin/nginx-wrapper
 
 # Mount elasticsearch.yml config
-ADD templates/elasticsearch.yml /elasticsearch/config/elasticsearch.yml
+ADD templates/elasticsearch.yml.template /elasticsearch/config/elasticsearch.yml.template
 
+ADD extract_es_settings.py /usr/bin/
 ADD run-database.sh /usr/bin/
 ADD utilities.sh /usr/bin/
 
@@ -57,4 +61,10 @@ VOLUME ["$SSL_DIRECTORY"]
 EXPOSE 80
 EXPOSE 443
 
+# Expose ElasticSearch transport port
+EXPOSE 9300
+
+
+# TOOD - Supervisor? Looks like terminating Nginx will kill
+# Elastic brutally here..!
 ENTRYPOINT ["run-database.sh"]

--- a/1.5/extract_es_settings.py
+++ b/1.5/extract_es_settings.py
@@ -1,0 +1,21 @@
+#!/usr/bin/env python
+import sys
+import json
+import re
+
+
+def main():
+    cluster_info = json.load(sys.stdin)
+    print "CLUSTER_NAME='{0}'".format(cluster_info["cluster_name"])
+
+    node_addresses = []
+    for node in cluster_info["nodes"].values():
+        m = re.match(r"inet\[/(.+)\]", node["transport_address"])
+        node_addresses.append(m.group(1))
+
+    print "CLUSTER_HOSTS='{0}'".format(','.join(node_addresses))
+
+
+if __name__ == "__main__":
+    # Expect to be passed the (JSON) output of http://.../_nodes
+    main()

--- a/1.5/run-database.sh
+++ b/1.5/run-database.sh
@@ -64,6 +64,8 @@ elif [[ "$1" == "--activate-leader" ]]; then
 elif [[ "$1" == "--initialize-from" ]]; then
   [ -z "$2" ] && echo "docker run aptible/elasticsearch --initialize-from https://..." && exit
 
+  # TODO - Certs
+
   echo "${ELASTIC_REPLICATION_HTACCESS}" > "${DATA_DIRECTORY}/auth_basic.htpasswd"
 
   # Get the cluster name and nodes, store them

--- a/1.5/run-database.sh
+++ b/1.5/run-database.sh
@@ -6,14 +6,18 @@ set -o pipefail
 . /usr/bin/utilities.sh
 
 
+# Environment variables that might be provided by the environmen
+
+: ${PUBLISH_HOST:=""}       # Host this container's ports may be published on.
+: ${PUBLISH_PORT_9300:=""}  # Port this container's port 9300 may be published on.
+: ${PUBLISH_PORT_443:=""}   # Similar to above.
+
 # File name constants
 ES_CLUSTER_NAME_FILE="${DATA_DIRECTORY}/cluster-name"
 ES_CLUSTER_HOSTS_FILE="${DATA_DIRECTORY}/cluster-hosts"
 
 
-sed "s:SSL_DIRECTORY:${SSL_DIRECTORY}:g" /etc/nginx/nginx.conf.template > /etc/nginx/nginx.conf
-
-function elastic_initialize_conf_dir () {
+function elastic_runtime_conf () {
   # Load cluster name
   if [[ -f "${ES_CLUSTER_NAME_FILE}" ]]; then
     CLUSTER_NAME="$(cat "${ES_CLUSTER_NAME_FILE}")"
@@ -30,52 +34,75 @@ function elastic_initialize_conf_dir () {
   es_config="/elasticsearch/config/elasticsearch.yml"
   cp "${es_config}"{.template,}
 
-  sed -i "s/__CLUSTER_NAME__/${CLUSTER_NAME}/g"             "${es_config}"
-  sed -i "s/__CLUSTER_HOSTS__/${CLUSTER_HOSTS}/g"           "${es_config}"
+  sed -i "s/__CLUSTER_NAME__/${CLUSTER_NAME}/g"   "${es_config}"
+  sed -i "s/__CLUSTER_HOSTS__/${CLUSTER_HOSTS}/g" "${es_config}"
 
-  # TODO - We probably should not expose those to always be available, or
-  # expect them to be provided under this name.
-  sed -i "s/__NODE_PUBLISH_HOST__/${NODE_PUBLISH_HOST}/g"   "${es_config}"
-  sed -i "s/__NODE_PUBLISH_PORT__/${NODE_PUBLISH_PORT}/g"   "${es_config}"
+
+  # If we have a publish host, write it in the config file. Otherwise,
+  # remove that section altogether. Same for port.
+
+  if [[ -n "${PUBLISH_HOST}"  ]]; then
+    sed -i "s/__NODE_PUBLISH_HOST__/${PUBLISH_HOST}/g" "${es_config}"
+  else
+    sed -i "/__NODE_PUBLISH_HOST__/d" "${es_config}"
+  fi
+
+  if [[ -n "${PUBLISH_PORT_9300}"  ]]; then
+    sed -i "s/__NODE_PUBLISH_PORT__/${PUBLISH_PORT_9300}/g" "${es_config}"
+  else
+    sed -i "/__NODE_PUBLISH_PORT__/d" "${es_config}"
+  fi
 }
 
 
-if [[ "$1" == "--initialize" ]]; then
-  # Nginx SSL Setup
-  htpasswd -b -c "${DATA_DIRECTORY}/auth_basic.htpasswd" "${USERNAME:-aptible}" "$PASSPHRASE"
+function nginx_runtime_conf () {
+  sed "s:__SSL_DIRECTORY__:${SSL_DIRECTORY}:g" /etc/nginx/nginx.conf.template > /etc/nginx/nginx.conf
+}
+
+
+function nginx_init_htpasswd () {
+  local user="$1"
+  local pass="$2"
+
+  htpasswd -b -c "${DATA_DIRECTORY}/auth_basic.htpasswd" "$user" "$pass"
+}
+
+
+function nginx_init_certs () {
+  # TODO - Run ES as separate user to prevent access to SSL certs.
   if [ -n "$SSL_CERTIFICATE" ] && [ -n "$SSL_KEY" ]; then
     echo "$SSL_CERTIFICATE" > "$SSL_DIRECTORY"/server.crt
     echo "$SSL_KEY" > "$SSL_DIRECTORY"/server.key
     chmod og-rwx "$SSL_DIRECTORY"/server.key
   fi
+}
 
-  # TODO - Run ES as separate user to prevent access to SSL certs.
 
-  # Discover cluster name, load up master host.
-  echo "Initializing cluster name"
+if [[ "$1" == "--initialize" ]]; then
+  set -o xtrace
+  nginx_init_htpasswd "${USERNAME:-aptible}" "$PASSPHRASE"
+  nginx_init_certs
+
   CLUSTER_NAME="es-$(pwgen -s 10)"
   echo "${CLUSTER_NAME}" > "${ES_CLUSTER_NAME_FILE}"
 
-elif [[ "$1" == "--activate-leader" ]]; then
-  # TODO - Document that this *needs* to have access to the master volumes.
-  # Export htaccess for slave to replicate.
-  echo "ELASTIC_REPLICATION_HTACCESS='$(cat "${DATA_DIRECTORY}/auth_basic.htpasswd")'"
-
 elif [[ "$1" == "--initialize-from" ]]; then
-  [ -z "$2" ] && echo "docker run aptible/elasticsearch --initialize-from https://..." && exit
+  [ -z "$2" ] && echo "docker run aptible/elasticsearch --initialize-from https://..." && exit 1
+  set -o xtrace
 
-  # TODO - Certs
+  # Parse out username and password
+  parse_url "$2"
 
-  echo "${ELASTIC_REPLICATION_HTACCESS}" > "${DATA_DIRECTORY}/auth_basic.htpasswd"
+  nginx_init_htpasswd "$user" "$password"
+  nginx_init_certs
 
-  # Get the cluster name and nodes, store them
-  # https://www.elastic.co/guide/en/elasticsearch/reference/1.5/cluster-nodes-info.html
-  # TODO - Do we want to keep --insecure here?
+  # Fetch cluster settings from master - ${2} is probably /-terminated, so we might end
+  # up with a // in here, but that's fine - better safe than sorry.
   es_settings="$(curl --insecure --silent "${2}/_nodes" | extract_es_settings.py)"
   eval "$es_settings"
 
   echo "${CLUSTER_NAME}" > "${DATA_DIRECTORY}/cluster-name"
-  echo "${CLUSTER_HOSTS}" > "${DATA_DIRECTORY}/cluster-hosts" # TODO - Do we need to update this periodically to register new hosts?
+  echo "${CLUSTER_HOSTS}" > "${DATA_DIRECTORY}/cluster-hosts"
 
 elif [[ "$1" == "--client" ]]; then
   echo "This image does not support the --client option. Use curl instead." && exit 1
@@ -90,12 +117,21 @@ elif [[ "$1" == "--restore" ]]; then
   parse_url "$2"
   elasticdump --bulk=true --input=$ --output=${protocol:-https}"://"$user":"$password"@"$host":"${port:-80}""
 
+elif [[ "$1" == "--info" ]]; then
+  if [[ -z "$USERNAME" ]] || [[ -z "$PASSPHRASE" ]] || [[ -z "$PUBLISH_HOST" ]] || [[ -z "$PUBLISH_PORT_443" ]]; then
+    echo "One of PUBLISH_HOST, USERNAME, PASSPHRASE, PUBLISH_PORT_443 is missing from the environment"
+    exit 1
+  fi
+  echo "CONNECTION_URL=https://${USERNAME}:${PASSPHRASE}@${PUBLISH_HOST}:${PUBLISH_PORT_443}/"
+
 elif [[ "$1" == "--readonly" ]]; then
-  elastic_initialize_conf_dir
+  elastic_runtime_conf
+  nginx_runtime_conf
   READONLY=1 /usr/sbin/nginx-wrapper
 
 else
-  elastic_initialize_conf_dir
+  elastic_runtime_conf
+  nginx_runtime_conf
   /usr/sbin/nginx-wrapper
 
 fi

--- a/1.5/run-database.sh
+++ b/1.5/run-database.sh
@@ -27,15 +27,14 @@ function elastic_initialize_conf_dir () {
     CLUSTER_HOSTS="[]"  # No hosts
   fi
 
-  # TODO - Fix this (!).
-  #NODE_PUBLISH_HOST="192.168.99.101"
-  #NODE_PUBLISH_PORT="1234"
-
   es_config="/elasticsearch/config/elasticsearch.yml"
   cp "${es_config}"{.template,}
 
   sed -i "s/__CLUSTER_NAME__/${CLUSTER_NAME}/g"             "${es_config}"
   sed -i "s/__CLUSTER_HOSTS__/${CLUSTER_HOSTS}/g"           "${es_config}"
+
+  # TODO - We probably should not expose those to always be available, or
+  # expect them to be provided under this name.
   sed -i "s/__NODE_PUBLISH_HOST__/${NODE_PUBLISH_HOST}/g"   "${es_config}"
   sed -i "s/__NODE_PUBLISH_PORT__/${NODE_PUBLISH_PORT}/g"   "${es_config}"
 }

--- a/1.5/run-database.sh
+++ b/1.5/run-database.sh
@@ -1,17 +1,69 @@
 #!/bin/bash
+set -o errexit
+set -o pipefail
+
 
 . /usr/bin/utilities.sh
 
 sed "s:SSL_DIRECTORY:${SSL_DIRECTORY}:g" /etc/nginx/nginx.conf.template > /etc/nginx/nginx.conf
 
+
+function elastic_initialize_conf_dir () {
+  # Load cluster name
+  if [[ -f "${DATA_DIRECTORY}/cluster-name" ]]; then
+    CLUSTER_NAME="$(cat "${DATA_DIRECTORY}/cluster-name")"
+  else
+    CLUSTER_NAME="elasticsearch"  # Old default
+  fi
+
+  if [[ -f "${DATA_DIRECTORY}/cluster-hosts" ]]; then
+    CLUSTER_HOSTS="$(cat "${DATA_DIRECTORY}/cluster-hosts")"
+  else
+    CLUSTER_HOSTS="[]"  # No hosts
+  fi
+
+  # TODO - Fix this (!).
+  #NODE_PUBLISH_HOST="192.168.99.101"
+  #NODE_PUBLISH_PORT="1234"
+  set -o nounset  # TODO
+
+  es_config="/elasticsearch/config/elasticsearch.yml"
+  cp "${es_config}"{.template,}
+
+  sed -i "s/__CLUSTER_NAME__/${CLUSTER_NAME}/g"             "${es_config}"
+  sed -i "s/__CLUSTER_HOSTS__/${CLUSTER_HOSTS}/g"           "${es_config}"
+  sed -i "s/__NODE_PUBLISH_HOST__/${NODE_PUBLISH_HOST}/g"   "${es_config}"
+  sed -i "s/__NODE_PUBLISH_PORT__/${NODE_PUBLISH_PORT}/g"   "${es_config}"
+}
+
+
 if [[ "$1" == "--initialize" ]]; then
+
+  # Nginx SSL Setup
   htpasswd -b -c "$DATA_DIRECTORY"/auth_basic.htpasswd "${USERNAME:-aptible}" "$PASSPHRASE"
   if [ -n "$SSL_CERTIFICATE" ] && [ -n "$SSL_KEY" ]; then
     echo "$SSL_CERTIFICATE" > "$SSL_DIRECTORY"/server.crt
     echo "$SSL_KEY" > "$SSL_DIRECTORY"/server.key
     chmod og-rwx "$SSL_DIRECTORY"/server.key
   fi
-  exit
+
+  # Discover cluster name, load up master host.
+  # TODO - Should we hit the master and find out about other hosts instead?
+  echo "Initializing cluster name"
+  CLUSTER_NAME="es-$(pwgen -s 10)"
+  echo "${CLUSTER_NAME}" > "${DATA_DIRECTORY}/cluster-name"
+
+elif [[ "$1" == "--initialize-from" ]]; then
+  set -o xtrace
+  [ -z "$2" ] && echo "docker run aptible/elasticsearch --initialize-from https://..." && exit
+  #parse_url "$2"
+
+  # Get the cluster name and nodes, store them
+  # https://www.elastic.co/guide/en/elasticsearch/reference/1.5/cluster-nodes-info.html
+  eval $(curl -s "${2}/_nodes" | extract_es_settings.py)
+
+  echo "${CLUSTER_NAME}" > "${DATA_DIRECTORY}/cluster-name"
+  echo "${CLUSTER_HOSTS}" > "${DATA_DIRECTORY}/cluster-hosts" # TODO - Update periodically?
 
 elif [[ "$1" == "--client" ]]; then
   echo "This image does not support the --client option. Use curl instead." && exit 1
@@ -30,6 +82,7 @@ elif [[ "$1" == "--readonly" ]]; then
   READONLY=1 /usr/sbin/nginx-wrapper
 
 else
+  elastic_initialize_conf_dir
   /usr/sbin/nginx-wrapper
 
 fi

--- a/1.5/templates/elasticsearch.yml
+++ b/1.5/templates/elasticsearch.yml
@@ -1,8 +1,0 @@
-discovery.zen.ping.multicast.enabled: false
-path:
-  data: /var/db/data
-  logs: /var/db/log
-  plugins: /elasticsearch/plugins
-  work: /var/db/work
-http.cors.enabled: true
-http.cors.allow-origin: "/.*/"

--- a/1.5/templates/elasticsearch.yml.template
+++ b/1.5/templates/elasticsearch.yml.template
@@ -1,0 +1,27 @@
+path:
+  data: /var/db/data
+  logs: /var/db/log
+  plugins: /elasticsearch/plugins
+  work: /var/db/work
+
+http:
+  cors:
+    enabled: true
+    allow-origin: "/.*/"
+
+
+cluster.name: __CLUSTER_NAME__
+
+http:
+  bind_host: 127.0.0.1
+
+transport:
+  # https://www.elastic.co/guide/en/elasticsearch/reference/1.5/modules-transport.html
+  bind_host: 0.0.0.0
+  tcp.port: 9300
+  publish_host: __NODE_PUBLISH_HOST__
+  publish_port: __NODE_PUBLISH_PORT__
+
+discovery.zen.ping:
+  multicast.enabled: false
+  unicast.hosts: __CLUSTER_HOSTS__

--- a/1.5/templates/elasticsearch.yml.template
+++ b/1.5/templates/elasticsearch.yml.template
@@ -13,6 +13,8 @@ http:
 cluster.name: __CLUSTER_NAME__
 
 http:
+  # Nginx is used as a reverse proxy for authentication, so we only listen on
+  # 127.0.0.1
   bind_host: 127.0.0.1
 
 transport:

--- a/1.5/templates/nginx.conf.template
+++ b/1.5/templates/nginx.conf.template
@@ -60,8 +60,8 @@ http {
     listen   443;
 
     ssl on;
-    ssl_certificate SSL_DIRECTORY/server.crt;
-    ssl_certificate_key SSL_DIRECTORY/server.key;
+    ssl_certificate __SSL_DIRECTORY__/server.crt;
+    ssl_certificate_key __SSL_DIRECTORY__/server.key;
 
     keepalive_timeout 5;
 

--- a/test.sh
+++ b/test.sh
@@ -1,0 +1,59 @@
+#!/bin/bash
+set -o errexit
+set -o nounset
+set -o xtrace
+
+
+VERSION="1.5"
+IMG="quay.io/aptible/elasticsearch:$VERSION"
+
+DATA="/tmp/docker-elasticsearch/data"
+
+ES_A_CONTAINER="es-a"
+ES_A_HTTPS_PORT=4431
+ES_A_TRANSPORT_PORT=19301
+
+ES_B_CONTAINER="es-b"
+ES_B_HTTPS_PORT=4432
+ES_B_TRANSPORT_PORT=19302
+
+ES_HTTPS_PORT=443
+ES_TRANSPORT_PORT=9300
+
+DOCKER_VM_HOST="192.168.99.100"  # TODO - Be more dynamic
+
+
+USERNAME="test"
+PASSPHRASE="testpass"
+
+
+
+# Cleanup
+docker rm -f "$ES_A_CONTAINER" "$ES_B_CONTAINER" || true
+docker-machine ssh docker-vm sudo rm -rf "${DATA}"
+
+# Image
+make 1.5
+
+
+
+echo "Running ES A"
+docker run -d --name "$ES_A_CONTAINER" \
+  -p "$ES_A_HTTPS_PORT:$ES_HTTPS_PORT" -p "$ES_A_TRANSPORT_PORT:$ES_TRANSPORT_PORT" \
+  -e NODE_PUBLISH_HOST="$DOCKER_VM_HOST" -e NODE_PUBLISH_PORT="$ES_A_TRANSPORT_PORT" \
+  -e USERNAME="$USERNAME" -e PASSPHRASE="$PASSPHRASE" \
+  --entrypoint bash \
+  "${IMG}" \
+  -c "run-database.sh --initialize && run-database.sh"
+
+# Wait for ES to be ready on the master
+until curl --insecure --silent --fail > /dev/null "https://$USERNAME:$PASSPHRASE@$DOCKER_VM_HOST:$ES_A_HTTPS_PORT"; do sleep 0.5; done
+
+echo "Running ES B (from A)"
+docker run -d --name "$ES_B_CONTAINER" \
+  -p "$ES_B_HTTPS_PORT:$ES_HTTPS_PORT" -p "$ES_B_TRANSPORT_PORT:$ES_TRANSPORT_PORT" \
+  -e NODE_PUBLISH_HOST="$DOCKER_VM_HOST" -e NODE_PUBLISH_PORT="$ES_B_TRANSPORT_PORT" \
+  --entrypoint bash \
+  "$IMG" \
+  -c "run-database.sh --initialize-from https://$USERNAME:$PASSPHRASE@$DOCKER_VM_HOST:$ES_A_HTTPS_PORT/ && run-database.sh"
+

--- a/test.sh
+++ b/test.sh
@@ -36,24 +36,39 @@ docker-machine ssh docker-vm sudo rm -rf "${DATA}"
 make 1.5
 
 
-
-echo "Running ES A"
+echo "Running ${ES_A_CONTAINER}"
 docker run -d --name "$ES_A_CONTAINER" \
   -p "$ES_A_HTTPS_PORT:$ES_HTTPS_PORT" -p "$ES_A_TRANSPORT_PORT:$ES_TRANSPORT_PORT" \
   -e NODE_PUBLISH_HOST="$DOCKER_VM_HOST" -e NODE_PUBLISH_PORT="$ES_A_TRANSPORT_PORT" \
   -e USERNAME="$USERNAME" -e PASSPHRASE="$PASSPHRASE" \
   --entrypoint bash \
+  -v "${DATA}/$ES_A_CONTAINER:/var/db" \
   "${IMG}" \
   -c "run-database.sh --initialize && run-database.sh"
 
-# Wait for ES to be ready on the master
+
+echo "Waiting for ${ES_A_CONTAINER} to come online"
 until curl --insecure --silent --fail > /dev/null "https://$USERNAME:$PASSPHRASE@$DOCKER_VM_HOST:$ES_A_HTTPS_PORT"; do sleep 0.5; done
 
-echo "Running ES B (from A)"
+
+echo "Extracting init data from ${ES_A_CONTAINER}"
+eval "$(docker run -it -v "${DATA}/${ES_A_CONTAINER}:/var/db" --rm "$IMG" --activate-leader | dos2unix)"
+
+
+echo "Running ${ES_B_CONTAINER} (from ${ES_A_CONTAINER})"
 docker run -d --name "$ES_B_CONTAINER" \
   -p "$ES_B_HTTPS_PORT:$ES_HTTPS_PORT" -p "$ES_B_TRANSPORT_PORT:$ES_TRANSPORT_PORT" \
   -e NODE_PUBLISH_HOST="$DOCKER_VM_HOST" -e NODE_PUBLISH_PORT="$ES_B_TRANSPORT_PORT" \
+  -e "ELASTIC_REPLICATION_HTACCESS=$ELASTIC_REPLICATION_HTACCESS" \
   --entrypoint bash \
+  -v "${DATA}/$ES_A_CONTAINER:/var/db" \
   "$IMG" \
   -c "run-database.sh --initialize-from https://$USERNAME:$PASSPHRASE@$DOCKER_VM_HOST:$ES_A_HTTPS_PORT/ && run-database.sh"
+
+
+echo "Waiting for ${ES_B_CONTAINER} to come online"
+until curl --insecure --silent --fail > /dev/null "https://$USERNAME:$PASSPHRASE@$DOCKER_VM_HOST:$ES_B_HTTPS_PORT"; do sleep 0.5; done
+
+
+echo "Running tests on ${ES_A_CONTAINER}, ${ES_B_CONTAINER}"
 

--- a/test.sh
+++ b/test.sh
@@ -9,23 +9,25 @@ IMG="quay.io/aptible/elasticsearch:$VERSION"
 
 DATA="/tmp/docker-elasticsearch/data"
 
+# TODO - Be more dynamic
+DOCKER_VM_HOST="192.168.99.100"
+
+ES_USERNAME="test"
+ES_PASSPHRASE="testpass"
+
+
 ES_A_CONTAINER="es-a"
 ES_A_HTTPS_PORT=4431
 ES_A_TRANSPORT_PORT=19301
+ES_A_URL="https://$ES_USERNAME:$ES_PASSPHRASE@$DOCKER_VM_HOST:$ES_A_HTTPS_PORT/"
 
 ES_B_CONTAINER="es-b"
 ES_B_HTTPS_PORT=4432
 ES_B_TRANSPORT_PORT=19302
+ES_B_URL="https://$ES_USERNAME:$ES_PASSPHRASE@$DOCKER_VM_HOST:$ES_B_HTTPS_PORT/"
 
 ES_HTTPS_PORT=443
 ES_TRANSPORT_PORT=9300
-
-DOCKER_VM_HOST="192.168.99.100"  # TODO - Be more dynamic
-
-
-USERNAME="test"
-PASSPHRASE="testpass"
-
 
 
 # Cleanup
@@ -36,39 +38,56 @@ docker-machine ssh docker-vm sudo rm -rf "${DATA}"
 make 1.5
 
 
+echo "Initializing ${ES_A_CONTAINER}"
+docker run -it --rm \
+  -v "${DATA}/${ES_A_CONTAINER}:/var/db" \
+  -e USERNAME="$ES_USERNAME" -e PASSPHRASE="$ES_PASSPHRASE" \
+  "$IMG" --initialize
+
+
 echo "Running ${ES_A_CONTAINER}"
 docker run -d --name "$ES_A_CONTAINER" \
   -p "$ES_A_HTTPS_PORT:$ES_HTTPS_PORT" -p "$ES_A_TRANSPORT_PORT:$ES_TRANSPORT_PORT" \
-  -e NODE_PUBLISH_HOST="$DOCKER_VM_HOST" -e NODE_PUBLISH_PORT="$ES_A_TRANSPORT_PORT" \
-  -e USERNAME="$USERNAME" -e PASSPHRASE="$PASSPHRASE" \
-  --entrypoint bash \
   -v "${DATA}/$ES_A_CONTAINER:/var/db" \
-  "${IMG}" \
-  -c "run-database.sh --initialize && run-database.sh"
+  -e PUBLISH_HOST="$DOCKER_VM_HOST" -e PUBLISH_PORT_9300="$ES_A_TRANSPORT_PORT" \
+  "${IMG}"
 
 
 echo "Waiting for ${ES_A_CONTAINER} to come online"
-until curl --insecure --silent --fail > /dev/null "https://$USERNAME:$PASSPHRASE@$DOCKER_VM_HOST:$ES_A_HTTPS_PORT"; do sleep 0.5; done
+until curl --insecure --silent --fail > /dev/null "$ES_A_URL"; do sleep 0.5; done
 
 
-echo "Extracting init data from ${ES_A_CONTAINER}"
-eval "$(docker run -it -v "${DATA}/${ES_A_CONTAINER}:/var/db" --rm "$IMG" --activate-leader | dos2unix)"
+echo "Initializing ${ES_B_CONTAINER} (from ${ES_A_CONTAINER})"
+docker run -it --rm \
+  -v "${DATA}/$ES_B_CONTAINER:/var/db" \
+  -e USERNAME="$ES_USERNAME" -e PASSPHRASE="$ES_PASSPHRASE" \
+  "$IMG" --initialize-from "$ES_A_URL"
 
 
-echo "Running ${ES_B_CONTAINER} (from ${ES_A_CONTAINER})"
+echo "Running ${ES_B_CONTAINER}"
 docker run -d --name "$ES_B_CONTAINER" \
   -p "$ES_B_HTTPS_PORT:$ES_HTTPS_PORT" -p "$ES_B_TRANSPORT_PORT:$ES_TRANSPORT_PORT" \
-  -e NODE_PUBLISH_HOST="$DOCKER_VM_HOST" -e NODE_PUBLISH_PORT="$ES_B_TRANSPORT_PORT" \
-  -e "ELASTIC_REPLICATION_HTACCESS=$ELASTIC_REPLICATION_HTACCESS" \
-  --entrypoint bash \
-  -v "${DATA}/$ES_A_CONTAINER:/var/db" \
-  "$IMG" \
-  -c "run-database.sh --initialize-from https://$USERNAME:$PASSPHRASE@$DOCKER_VM_HOST:$ES_A_HTTPS_PORT/ && run-database.sh"
+  -v "${DATA}/$ES_B_CONTAINER:/var/db" \
+  -e PUBLISH_HOST="$DOCKER_VM_HOST" -e PUBLISH_PORT_9300="$ES_B_TRANSPORT_PORT" \
+  "$IMG"
 
 
 echo "Waiting for ${ES_B_CONTAINER} to come online"
-until curl --insecure --silent --fail > /dev/null "https://$USERNAME:$PASSPHRASE@$DOCKER_VM_HOST:$ES_B_HTTPS_PORT"; do sleep 0.5; done
+until curl --insecure --silent --fail > /dev/null "$ES_B_URL"; do sleep 0.5; done
 
 
 echo "Running tests on ${ES_A_CONTAINER}, ${ES_B_CONTAINER}"
+curl --silent --insecure "${ES_A_URL}/_cluster/health" | python -c 'import json, sys; assert json.load(sys.stdin)["number_of_nodes"] == 2'
 
+
+# Create some data on ES-A!
+curl --insecure --fail -XPUT "${ES_A_URL}customer/?pretty=true"
+curl --insecure --fail -XPUT "${ES_A_URL}/customer/external/1?pretty=true" -d '{
+  "name": "John Doe"
+}'
+
+# Check out the data on ES-B!
+curl --silent --insecure --fail -XGET "${ES_B_URL}/customer/external/1?pretty"
+
+
+echo "Test OK!"


### PR DESCRIPTION
This isn't ready at all, but I think it's a good addition to our discussion on the API we need to expose for  replication / clustering.

- I think a `--activate-leader` style command will be needed, but it'll need to have access to *something* `--initialize-follower` doesn't have access to to be any useful. I think access to the leader's data volumes would be a good choice (`docker exec`'ing into the leader's container might be another one). In Elastic's case, this privileged access would be needed to copy over the htaccess data from the leader's Nginx to the new member.

- ElasticSearch needs cluster members to have some awareness of how they can be reached from other nodes (see the code in `elastic_initialize_conf_dir` — it needs a host and a port that other nodes will use to reach port 9300 in the container). This information should probably be provided by Sweetness (with a decent fallback if is missing to help in development). It doesn't need to be database-specific. I think it could be provided in a generic format through e.g. an environment variable containing JSON or a mounted file.

- ElasticSearch uses a new port for client requests (9200, which we reverse proxy on 80 and 443) and clustering (9300). However, Sweetness currently expects databases to expose a single port. We'd need to change that, all the while allowing Sweetness to somehow know which port needs to be communicated to end users for the database. This information could be provided to Sweetness through a `--info` command available in database images, and if Sweetness is providing the hostname and port (as mentioned above), the `--info` command could also perhaps return the entire database URL (thus reducing the footprint of Sweetness DB handlers).

- So far, all `--initialize-follower` commands (or `--initialize-from` as I've called it here, which might be a more appropriate command name) have needed a master database URL, but in MySQL's case, that URL doesn't match the one Sweetness knows (it needs to use the `root` user, not the `aptible` one). I think we should give the `--activate-leader` full control over the initialization parameters given to the follower, so that Sweetness doesn't need to know anything about them. However, this would once again require a given database container to know about its public host and port mappings so it can generate an appropriate database URL.

cc @fancyremarker , @aaw 

---

Note: this doesn't support authentication nor encryption on the transport layer. This is a longer discussion, [covered in this Google doc][10].

  [10]: https://docs.google.com/document/d/1ld2nh9UmJ_1ndMiEI3z3sIVnI83-oFuzWnj1N68YNes/edit