### PR TITLE
Ensure the container exits when ES exits

### DIFF
--- a/Dockerfile.erb
+++ b/Dockerfile.erb
@@ -56,7 +56,8 @@ RUN rm /etc/nginx/nginx.conf
 RUN rm /elasticsearch/config/elasticsearch.yml
 
 # Wrappers
-ADD bin/nginx-wrapper /usr/sbin/nginx-wrapper
+ADD bin/cluster-wrapper /usr/bin/cluster-wrapper
+ADD bin/nginx-wrapper /usr/bin/nginx-wrapper
 ADD bin/elasticsearch-wrapper /usr/bin/elasticsearch-wrapper
 
 ADD bin/run-database.sh /usr/bin/

--- a/bin/cluster-wrapper
+++ b/bin/cluster-wrapper
@@ -1,0 +1,4 @@
+#!/bin/sh
+set -o errexit
+/usr/bin/nginx-wrapper &
+exec /usr/bin/elasticsearch-wrapper

--- a/bin/elasticsearch-wrapper
+++ b/bin/elasticsearch-wrapper
@@ -1,2 +1,2 @@
-#!/bin/bash
+#!/bin/sh
 exec sudo -u "$ES_USER" /elasticsearch/bin/elasticsearch "$@"

--- a/bin/nginx-wrapper
+++ b/bin/nginx-wrapper
@@ -17,5 +17,4 @@ if [ -n "$READONLY" ]; then
   sed -i 's/\#RO //g' /etc/nginx/nginx.conf
 fi
 
-/usr/bin/elasticsearch-wrapper &
-/usr/sbin/nginx "$@"
+exec /usr/sbin/nginx "$@"

--- a/bin/run-database.sh
+++ b/bin/run-database.sh
@@ -38,9 +38,7 @@ elif [[ "$1" == "--restore" ]]; then
   elasticdump --bulk=true '--input=$' --output="${protocol:-"https://"}${user}:${password}@${host}:${port:-80}"
 
 elif [[ "$1" == "--readonly" ]]; then
-  READONLY=1 /usr/sbin/nginx-wrapper
-
+  READONLY=1 exec /usr/bin/cluster-wrapper
 else
-  /usr/sbin/nginx-wrapper
-
+  exec /usr/bin/cluster-wrapper
 fi

--- a/test.sh
+++ b/test.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+set -o errexit
+set -o nounset
+
+IMG="$REGISTRY/$REPOSITORY:$TAG"
+
+ES_CONTAINER="es-db"
+DATA_CONTAINER="es-data"
+
+function cleanup {
+  echo "Cleaning up"
+  docker rm -f "$ES_CONTAINER" "$DATA_CONTAINER" || true
+}
+trap cleanup EXIT
+cleanup
+
+
+docker create --name "$DATA_CONTAINER" "$IMG"
+docker run -it --rm --volumes-from "$DATA_CONTAINER" "$IMG" --initialize
+docker run -d --name "$ES_CONTAINER" --volumes-from "$DATA_CONTAINER"  "$IMG"
+
+echo "Waiting for container to start"
+until docker logs "$ES_CONTAINER" | grep --silent "started"; do sleep 0.5; done
+
+echo "Terminating $ES_CONTAINER"
+docker stop "$ES_CONTAINER"
+
+until [[ "$(docker inspect -f "{{ .State.Pid }}" "$ES_CONTAINER")" -eq 0 ]]; do sleep 0.5; done
+
+echo "Checking container exited cleanly"
+docker logs "$ES_CONTAINER" | grep "stopped"
+docker logs "$ES_CONTAINER" | grep "closed"
+
+echo "Checking Elasticsearch exit code was propagated"
+exit_code="$(docker inspect -f "{{ .State.ExitCode }}" "$ES_CONTAINER")"
+[[ "$exit_code" -eq "$((128+15))" ]]
+
+echo "Test OK!"


### PR DESCRIPTION
This patch ensures PID 1 is more Elasticsearch than Nginx (in practice it's sudo, but sudo will exit if Elasticsearch exits).

Note: a cleaner solution would actually be to use a process supervisor or Tini (if I merge in https://github.com/krallin/tini/issues/28), but I don't think it's worth bothering here.

cc @fancyremarker 

--

This patch runs `sudo` as PID 1 instead of `nginx`.

Arguably, `sudo` isn't an idea init, so we *might* want to use something
like `gosu` to run ES itself as PID 1 (and `tini` if it turns out ES
doesn't like running as PID 1), but I haven't run into any issues in
testing, so in the interest of making minimal changes, I've let `sudo`
run as PID 1.