### PR TITLE
Captain comeback support (Add restart test)

### DIFF
--- a/test-exit-code.sh
+++ b/test-exit-code.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+set -o errexit
+set -o nounset
+
+IMG="$1"
+
+ES_CONTAINER="es-db"
+DATA_CONTAINER="es-data"
+
+function cleanup {
+  echo "Cleaning up"
+  docker rm -f "$ES_CONTAINER" "$DATA_CONTAINER" || true
+}
+trap cleanup EXIT
+cleanup
+
+
+docker create --name "$DATA_CONTAINER" "$IMG"
+docker run -it --rm --volumes-from "$DATA_CONTAINER" "$IMG" --initialize
+docker run -d --name "$ES_CONTAINER" --volumes-from "$DATA_CONTAINER"  "$IMG"
+
+echo "Waiting for container to start"
+until docker logs "$ES_CONTAINER" | grep --silent "started"; do sleep 0.5; done
+
+echo "Terminating $ES_CONTAINER"
+docker stop "$ES_CONTAINER"
+
+until [[ "$(docker inspect -f "{{ .State.Pid }}" "$ES_CONTAINER")" -eq 0 ]]; do sleep 0.5; done
+
+echo "Checking container exited cleanly"
+docker logs "$ES_CONTAINER" | grep "stopped"
+docker logs "$ES_CONTAINER" | grep "closed"
+
+echo "Checking Elasticsearch exit code was propagated"
+exit_code="$(docker inspect -f "{{ .State.ExitCode }}" "$ES_CONTAINER")"
+[[ "$exit_code" -eq "$((128+15))" ]]
+
+echo "Test OK!"

--- a/test-restart.sh
+++ b/test-restart.sh
@@ -1,0 +1,73 @@
+#!/bin/bash
+set -o errexit
+set -o nounset
+
+IMG="$1"
+
+DB_CONTAINER="elastic"
+DATA_CONTAINER="${DB_CONTAINER}-data"
+
+function cleanup {
+  echo "Cleaning up"
+  docker rm -f "$DB_CONTAINER" "$DATA_CONTAINER" >/dev/null 2>&1 || true
+}
+
+function wait_for_db {
+  for _ in $(seq 1 1000); do
+    if docker exec -it "$DB_CONTAINER" curl -fs "http://localhost:9200" >/dev/null 2>&1; then
+      return 0
+    fi
+    sleep 0.1
+  done
+
+  echo "DB never came online"
+  docker logs "$DB_CONTAINER"
+  return 1
+}
+
+trap cleanup EXIT
+cleanup
+
+echo "Creating data container"
+docker create --name "$DATA_CONTAINER" "$IMG"
+
+echo "Starting DB"
+docker run -it --rm \
+  -e USERNAME=user -e PASSPHRASE=pass -e DATABASE=db \
+  --volumes-from "$DATA_CONTAINER" \
+  "$IMG" --initialize \
+  >/dev/null 2>&1
+
+docker run -d --name="$DB_CONTAINER" \
+  -e EXPOSE_HOST=127.0.0.1 -e EXPOSE_PORT_27217=27217 \
+  --volumes-from "$DATA_CONTAINER" \
+  "$IMG"
+
+echo "Waiting for DB to come online"
+wait_for_db
+
+echo "Verifying DB shutdown message isn't present"
+docker logs "$DB_CONTAINER" 2>&1 | grep -vqiE "node.+closed"
+
+echo "Restarting DB container"
+date
+docker top "$DB_CONTAINER"
+docker restart -t 10 "$DB_CONTAINER"
+
+echo "Waiting for DB to come back online"
+wait_for_db
+
+echo "DB came back online; checking for clean shutdown and recovery"
+date
+docker logs "$DB_CONTAINER" 2>&1 | grep -qiE "node.+closed"
+
+echo "Attempting unclean shutdown"
+docker kill -s KILL "$DB_CONTAINER"
+docker start "$DB_CONTAINER"
+
+echo "Waiting for DB to come back online"
+wait_for_db
+
+echo "Checking DB started 3 times"
+n_starts="$(docker logs "$DB_CONTAINER" 2>&1 | grep -icE "recovered.+indices into cluster_state")"
+[[ "$n_starts" -eq 3 ]]

--- a/test.sh
+++ b/test.sh
@@ -4,35 +4,9 @@ set -o nounset
 
 IMG="$REGISTRY/$REPOSITORY:$TAG"
 
-ES_CONTAINER="es-db"
-DATA_CONTAINER="es-data"
+./test-restart.sh "$IMG"
+./test-exit-code.sh "$IMG"
 
-function cleanup {
-  echo "Cleaning up"
-  docker rm -f "$ES_CONTAINER" "$DATA_CONTAINER" || true
-}
-trap cleanup EXIT
-cleanup
-
-
-docker create --name "$DATA_CONTAINER" "$IMG"
-docker run -it --rm --volumes-from "$DATA_CONTAINER" "$IMG" --initialize
-docker run -d --name "$ES_CONTAINER" --volumes-from "$DATA_CONTAINER"  "$IMG"
-
-echo "Waiting for container to start"
-until docker logs "$ES_CONTAINER" | grep --silent "started"; do sleep 0.5; done
-
-echo "Terminating $ES_CONTAINER"
-docker stop "$ES_CONTAINER"
-
-until [[ "$(docker inspect -f "{{ .State.Pid }}" "$ES_CONTAINER")" -eq 0 ]]; do sleep 0.5; done
-
-echo "Checking container exited cleanly"
-docker logs "$ES_CONTAINER" | grep "stopped"
-docker logs "$ES_CONTAINER" | grep "closed"
-
-echo "Checking Elasticsearch exit code was propagated"
-exit_code="$(docker inspect -f "{{ .State.ExitCode }}" "$ES_CONTAINER")"
-[[ "$exit_code" -eq "$((128+15))" ]]
-
-echo "Test OK!"
+echo "#############"
+echo "# Tests OK! #"
+echo "#############"


### PR DESCRIPTION
This ensures compatibility of our Redis image with Captain Comeback's
`docker restart` workflow.

Unfortunately, ES doesn't report an unclean shutdown differently from a
regular one (at least not in a trivial case like this one), but our test
can still prove that the shutdown happened cleanly as far as we're
concerned by looking at Elastic's "node closed" exit message.