### PR TITLE
Support passing certificate at runtime

### DIFF
--- a/bin/elasticsearch-wrapper
+++ b/bin/elasticsearch-wrapper
@@ -32,9 +32,4 @@ if [[ -n "${ES_HEAP_SIZE:-}" ]]; then
   fi
 fi
 
-# ES doesn't need these variables, so we might as well drop them explicitly
-# (sudo will drop them anyway).
-unset SSL_CERTIFICATE
-unset SSL_KEY
-
 exec sudo -E -u "$ES_USER" /elasticsearch/bin/elasticsearch "$@"

--- a/bin/nginx-wrapper
+++ b/bin/nginx-wrapper
@@ -1,19 +1,15 @@
 #!/bin/sh
+set -o errexit
+set -o nounset
 
-SUBJ="/C=US/ST=New York/L=New York/O=Example/CN=elasticsearch.example.com"
-if [ ! -f "$SSL_DIRECTORY"/server.crt ] && [ ! -f "$SSL_DIRECTORY"/server.key ]; then
-  OPTS="req -nodes -new -x509 -sha256"
-  #shellcheck disable=SC2086
-  openssl $OPTS -subj "$SUBJ" -keyout "$SSL_DIRECTORY"/server.key -out "$SSL_DIRECTORY"/server.crt 2> /dev/null
-fi
+AUTH_FILE="${DATA_DIRECTORY}/auth_basic.htpasswd"
 
-AUTH_FILE="$DATA_DIRECTORY"/auth_basic.htpasswd
 if [ -f "$AUTH_FILE" ]; then
   ln -sf "$AUTH_FILE" /etc/nginx
   sed -i 's/\# auth_basic/auth_basic/' /etc/nginx/nginx.conf
 fi
 
-if [ -n "$READONLY" ]; then
+if [ -n "${READONLY:-}" ]; then
   sed -i 's/\#RO //g' /etc/nginx/nginx.conf
 fi
 

--- a/bin/run-database.sh
+++ b/bin/run-database.sh
@@ -3,20 +3,55 @@
 #shellcheck disable=SC1091
 . /usr/bin/utilities.sh
 
-sed "s:SSL_DIRECTORY:${SSL_DIRECTORY}:g" /etc/nginx/nginx.conf.template > /etc/nginx/nginx.conf
+function setup_runtime_configuration() {
+  sed "s:SSL_DIRECTORY:${SSL_DIRECTORY}:g" /etc/nginx/nginx.conf.template \
+    > /etc/nginx/nginx.conf
 
-sed "s:SSL_DIRECTORY:${SSL_DIRECTORY}:g" "/elasticsearch/config/elasticsearch.yml.template" \
-  | sed "s:DATA_DIRECTORY:${DATA_DIRECTORY}:g" \
-  > "/elasticsearch/config/elasticsearch.yml"
+  sed "s:SSL_DIRECTORY:${SSL_DIRECTORY}:g" "/elasticsearch/config/elasticsearch.yml.template" \
+    | sed "s:DATA_DIRECTORY:${DATA_DIRECTORY}:g" \
+    > "/elasticsearch/config/elasticsearch.yml"
 
-if [[ "$1" == "--initialize" ]]; then
-  htpasswd -b -c "$DATA_DIRECTORY"/auth_basic.htpasswd "${USERNAME:-aptible}" "$PASSPHRASE"
+  mkdir -p "$SSL_DIRECTORY"
+
+  local ssl_cert_file="${SSL_DIRECTORY}/server.crt"
+  local ssl_key_file="${SSL_DIRECTORY}/server.key"
 
   if [ -n "$SSL_CERTIFICATE" ] && [ -n "$SSL_KEY" ]; then
-    echo "$SSL_CERTIFICATE" > "$SSL_DIRECTORY"/server.crt
-    echo "$SSL_KEY" > "$SSL_DIRECTORY"/server.key
-    chmod og-rwx "$SSL_DIRECTORY"/server.key
+    echo "Cert present in environment - using them"
+    echo "$SSL_CERTIFICATE" > "$ssl_cert_file"
+    echo "$SSL_KEY" > "$ssl_key_file"
+  elif [ -f "$ssl_cert_file" ] && [ -f "$ssl_key_file" ]; then
+    echo "Cert present on filesystem - using them"
+  else
+    echo "Cert not found - autogenerating"
+    SUBJ="/C=US/ST=New York/L=New York/O=Example/CN=elasticsearch.example.com"
+    OPTS="req -nodes -new -x509 -sha256"
+    # shellcheck disable=2086
+    openssl $OPTS -subj "$SUBJ" -keyout "$ssl_key_file" -out "$ssl_cert_file" 2>/dev/null
   fi
+
+  unset SSL_CERTIFICATE
+  unset SSL_KEY
+
+  chmod 600 "$ssl_key_file"
+}
+
+
+if [[ "$#" -eq 0 ]]; then
+  setup_runtime_configuration
+  exec /usr/bin/cluster-wrapper
+
+elif [[ "$1" == "--readonly" ]]; then
+  setup_runtime_configuration
+  export READONLY=1
+  exec /usr/bin/cluster-wrapper
+
+elif [[ "$1" == "--initialize" ]]; then
+  # NOTE: Technically we're not going to use the runtime configuration, but we
+  # use setup_runtime_configuration to grab the cert and persist it to disk if
+  # it was provided in the environment.
+  setup_runtime_configuration
+  htpasswd -b -c "${DATA_DIRECTORY}/auth_basic.htpasswd" "${USERNAME:-aptible}" "$PASSPHRASE"
 
   es_dirs=("${DATA_DIRECTORY}/data" "${DATA_DIRECTORY}/log" "${DATA_DIRECTORY}/work" "${DATA_DIRECTORY}/scripts" "/elasticsearch/config")
   mkdir -p "${es_dirs[@]}"
@@ -49,8 +84,7 @@ elif [[ "$1" == "--restore" ]]; then
   # shellcheck disable=SC2154
   elasticdump --bulk=true '--input=$' --output="${protocol:-"https://"}${user}:${password}@${host}:${port:-80}"
 
-elif [[ "$1" == "--readonly" ]]; then
-  READONLY=1 exec /usr/bin/cluster-wrapper
 else
-  exec /usr/bin/cluster-wrapper
+  echo "Unrecognized command: $1"
+  exit 1
 fi


### PR DESCRIPTION
Currently, our image allows passing in a certificate at --initialize,
and will reuse that cert when it starts later on. If no cert was
provided, on will be auto-generated when the database starts.

This works well as long as the certificate doesn't change, but we'll
soon be replacing the certificate for `*.aptible.in`, so our image
should ideally start accepting a renewed certificate on restart.

---

cc @fancyremarker 