### PR TITLE
Docker 1.5 compatibility

### DIFF
--- a/Dockerfile.erb
+++ b/Dockerfile.erb
@@ -35,7 +35,8 @@ RUN NEW_REPO="https://artifacts.elastic.co/downloads/elasticsearch" \
  && tar xf "elasticsearch-${ES_VERSION}.tar.gz" \
  && rm "elasticsearch-${ES_VERSION}.tar.gz" \
  && mv "elasticsearch-${ES_VERSION}" /elasticsearch \
- && "/elasticsearch/bin/${PLUGIN}" install <%= '--batch' if ENV.fetch('TAG').start_with? '2.' %> "${ES_BACKUP_PLUGIN}"
+ && "/elasticsearch/bin/${PLUGIN}" install <%= '--batch' if ENV.fetch('TAG').start_with? '2.' %> "${ES_BACKUP_PLUGIN}" \
+ && chown -R "${ES_USER}:${ES_GROUP}" "/elasticsearch/config"
 
 # Install node.js and elasticdump tool for --dump/--restore options.
 # https://github.com/taskrabbit/elasticsearch-dump

--- a/bin/run-database.sh
+++ b/bin/run-database.sh
@@ -53,7 +53,10 @@ elif [[ "$1" == "--initialize" ]]; then
   setup_runtime_configuration
   htpasswd -b -c "${DATA_DIRECTORY}/auth_basic.htpasswd" "${USERNAME:-aptible}" "$PASSPHRASE"
 
-  es_dirs=("${DATA_DIRECTORY}/data" "${DATA_DIRECTORY}/log" "${DATA_DIRECTORY}/work" "${DATA_DIRECTORY}/scripts" "/elasticsearch/config")
+  # WARNING: Don't touch any directory that's not on DATA_DIRECTORY or
+  # SSL_DIRECTORY here: your changes wouldn't be persisted from --initialize to
+  # runtime.
+  es_dirs=("${DATA_DIRECTORY}/data" "${DATA_DIRECTORY}/log" "${DATA_DIRECTORY}/work" "${DATA_DIRECTORY}/scripts")
   mkdir -p "${es_dirs[@]}"
   chown -R "${ES_USER}:${ES_GROUP}" "${es_dirs[@]}"
 


### PR DESCRIPTION
On Docker 1.5, the `/elasticsearch/config/repository-s3` directory gets
into an awkward state and cannot be accessed by the Elasticsearch user.

Moving the directory to another name and then moving back fixes it,
which suggests this might be caused by an AUFS bug causing the wrong
permissions to be used (this is very similar to the issues we've had
with registries breaking because Nginx couldn't access its temporary
files directory).

See e.g. [this failed Sweetness build][0] for an error caused by this.

I haven't been able to reproduce the issue on other Docker versions,
although I have been able to reproduce the exact same Travis issue in a
VM running Docker 1.5.

This patch bypasses the issue by creating the directory and updating its
permissions in the same AUFS layer.

Arguably, this is a better approach anyway: this directory isn't mounted
on a volume, so changes to permissions aren't persisted and we shouldn't
be touching them during `--initialize`.

Note that in practice, that directory ended up having the right
permissions (and as such the image works on newer versions of Docker) in
the resulting image anyway, because the permission change happened
during tests, but that's not desirable for the long-term. I've added a
comment warning future me against making this mistake again (and others
as well!).

[0]: https://travis-ci.com/aptible/sweetness/jobs/60051861