### PR TITLE
Revert Elasticsearch 1.5 to JRE 7.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,10 @@ services:
   - docker
 
 env:
+  global:
+    # Credentials for arn:aws:iam::916150859591:user/travis-docker-elasticsearch
+    - secure: prrYqbvKiVTSZhbOz2szoVbQN/pOjvkh7/jkSGMmqVcWR2NSMfVprlvrEoVvq9dc4iEv8u6vQ4w/QMWpfozmRK+dyeM1EhIWD5qBMU4zOg9iGIIDqMRx/aaxez2PafkggP/u2Wpov1btqpV5F8yVseNUwBA4OkUFHAHujvJ2mmY=
+    - secure: Oj9Qh9fy+0fx9RaiyIbl115sa8DRUBLSNUrrjn4F71bSvFFPQ80ub9RRrnSKiAT5etYLkiqFlk8JCOibIjmNMRqcIyBesJ0kVru4GppyCpDMy9btxpGIlXrje3/SJqfJ9CiGyjLGmPN1YGsTdVSmTD45HQKfHCsoO7qqNhAjpww=
   matrix:
     - TAG=1.5
     - TAG=2.2

--- a/1.5/config.mk
+++ b/1.5/config.mk
@@ -4,4 +4,4 @@ export ES_BACKUP_PLUGIN = elasticsearch/elasticsearch-cloud-aws/2.5.1
 export ES_USER = root
 export ES_GROUP = root
 
-export JAVA_VERSION = 8
+export JAVA_VERSION = 7

--- a/1.5/test/elasticsearch-1.5.bats
+++ b/1.5/test/elasticsearch-1.5.bats
@@ -8,3 +8,8 @@
 @test "It should have the cloud-aws plugin installed" {
   /elasticsearch/bin/plugin --list | grep -q "cloud-aws"
 }
+
+@test "It should have JRE 7 installed" {
+  run java -version
+  [[ "$output" =~ "1.7" ]]
+}

--- a/Dockerfile.erb
+++ b/Dockerfile.erb
@@ -11,10 +11,8 @@ RUN apt-install software-properties-common apache2-utils sudo curl
 
 # Install Java and clean up
 ENV JAVA_VERSION <%= ENV.fetch 'JAVA_VERSION' %>
-RUN echo "oracle-java${JAVA_VERSION}-installer shared/accepted-oracle-license-v1-1 " \
-         "select true" | debconf-set-selections && \
-    add-apt-repository -y ppa:webupd8team/java && \
-    apt-install "oracle-java${JAVA_VERSION}-installer"
+RUN add-apt-repository -y ppa:openjdk-r/ppa && \
+    apt-install "openjdk-${JAVA_VERSION}-jre"
 
 # Install NGiNX
 RUN add-apt-repository -y ppa:nginx/stable && \

--- a/test-backup.sh
+++ b/test-backup.sh
@@ -1,0 +1,73 @@
+#!/bin/bash
+set -o errexit
+set -o nounset
+
+IMG="$1"
+
+DB_CONTAINER="elastic"
+DATA_CONTAINER="${DB_CONTAINER}-data"
+
+S3_BUCKET="${S3_BUCKET:-aptible-unit-tests}"
+AWS_ACCESS_KEY_ID="${AWS_ACCESS_KEY_ID}"
+AWS_SECRET_ACCESS_KEY="${AWS_SECRET_ACCESS_KEY}"
+S3_REGION="${S3_REGION:-us-east-1}"
+S3_BUCKET_BASE_PATH="${S3_BUCKET_BASE_PATH:-}"
+
+REPOSITORY_URL="http://user:pass@localhost:9200/_snapshot/logstash_snapshots"
+
+json=$(cat << EOF
+{
+  "type": "s3",
+  "settings": {
+    "bucket" : "${S3_BUCKET}",
+    "base_path": "${S3_BUCKET_BASE_PATH}",
+    "access_key": "${AWS_ACCESS_KEY_ID}",
+    "secret_key": "${AWS_SECRET_ACCESS_KEY}",
+    "region": "${S3_REGION}",
+    "protocol": "https",
+    "server_side_encryption": true
+  }
+}
+EOF
+)
+
+function cleanup {
+  echo "Cleaning up"
+  docker rm -f "$DB_CONTAINER" "$DATA_CONTAINER" >/dev/null 2>&1 || true
+}
+
+function wait_for_s3 {
+
+  for _ in $(seq 1 60); do
+    if docker exec "$DB_CONTAINER" curl -w "\n" -sS -XPUT "${REPOSITORY_URL}" -d "$json" | grep '{\"acknowledged\":true}'; then
+      echo "S3 backup succeeded."
+      return 0
+    fi
+    sleep 1
+  done
+
+  echo "S3 plugin did not work"
+  docker logs "$DB_CONTAINER"
+  return 1
+}
+
+trap cleanup EXIT
+cleanup
+
+echo "Creating data container"
+docker create --name "$DATA_CONTAINER" "$IMG"
+
+echo "Initializing DB"
+docker run -it --rm \
+  -e USERNAME=user -e PASSPHRASE=pass -e DATABASE=db \
+  --volumes-from "$DATA_CONTAINER" \
+  "$IMG" --initialize \
+  >/dev/null 2>&1
+
+echo "Starting DB"
+docker run -d --name="$DB_CONTAINER" \
+  -e EXPOSE_HOST=127.0.0.1 -e EXPOSE_PORT_27217=27217 \
+  --volumes-from "$DATA_CONTAINER" \
+  "$IMG"
+
+wait_for_s3

--- a/test-plugin.sh
+++ b/test-plugin.sh
@@ -63,7 +63,3 @@ docker run -d --name="$DB_CONTAINER" \
 for PLUGIN in $PLUGINS; do
   wait_for_plugin "$PLUGIN"
 done
-
-echo "Destroying"
-docker stop "$DB_CONTAINER"
-docker rm "$DB_CONTAINER"

--- a/test.sh
+++ b/test.sh
@@ -9,6 +9,12 @@ IMG="$REGISTRY/$REPOSITORY:$TAG"
 ./test-xpack.sh "$IMG"
 ./test-plugin.sh "$IMG"
 
+if [[ -n ${AWS_ACCESS_KEY_ID:-} ]]; then
+  ./test-backup.sh "$IMG"
+else
+  echo "Skipping S3 backup test, no AWS_ACCESS_KEY_ID set."
+fi
+
 echo "#############"
 echo "# Tests OK! #"
 echo "#############"

--- a/test/elasticsearch-all.bats
+++ b/test/elasticsearch-all.bats
@@ -56,22 +56,22 @@ teardown() {
   initialize_elasticsearch
   rm "$DATA_DIRECTORY/auth_basic.htpasswd"  # Disable auth for this test
   wait_for_elasticsearch
-  run wget -qO- http://localhost > "${BATS_TEST_DIRNAME}/test-output"
-  run wget -qO- http://localhost
+  run curl  http://localhost > "${BATS_TEST_DIRNAME}/test-output"
+  run curl http://localhost
   [[ "$output" =~ "tagline"  ]]
 }
 
 @test "It should expose Elasticsearch over HTTP with Basic Auth" {
   initialize_elasticsearch
   wait_for_elasticsearch
-  run wget -qO- http://aptible:password@localhost
+  run curl http://aptible:password@localhost
   [[ "$output" =~ "tagline"  ]]
 }
 
 @test "It should expose Elasticsearch over HTTPS with Basic Auth" {
   initialize_elasticsearch
   wait_for_elasticsearch
-  run wget -qO- --no-check-certificate https://aptible:password@localhost
+  run curl -k https://aptible:password@localhost
   [[ "$output" =~ "tagline"  ]]
 }
 
@@ -104,17 +104,17 @@ teardown() {
 @test "It should reject unauthenticated requests with Basic Auth enabled over HTTP" {
   initialize_elasticsearch
   wait_for_elasticsearch
-  run wget -qO- http://localhost
-  [ "$status" -ne "0" ]
-  ! [[ "$output" =~ "tagline"  ]]
+  run curl --fail http://localhost
+  [[ "$status" -eq 22 ]]  # CURLE_HTTP_RETURNED_ERROR - https://curl.haxx.se/libcurl/c/libcurl-errors.html
+  [[ "$output" =~ "401 Unauthorized"  ]]
 }
 
 @test "It should reject unauthenticated requests with Basic Auth enabled over HTTPS" {
   initialize_elasticsearch
   wait_for_elasticsearch
-  run wget -qO- --no-check-certificate https://localhost
-  [ "$status" -ne "0" ]
-  ! [[ "$output" =~ "tagline"  ]]
+  run curl -k --fail https://localhost
+  [[ "$status" -eq 22 ]]  # CURLE_HTTP_RETURNED_ERROR - https://curl.haxx.se/libcurl/c/libcurl-errors.html
+  [[ "$output" =~ "401 Unauthorized"  ]]
 }
 
 @test "It should not send multicast discovery ping requests" {


### PR DESCRIPTION
Oracle Java archived the 1.7 installer, so this also switch all versions from Oracle to OpenJDK.

Removed `wget` in favor of `curl`.

Adds a script that can test https://github.com/aptible/elasticsearch-logstash-s3-backup
This will only run if S3_BUCKET is set; ie only on TravisCI.