### PR TITLE
Add support for ES 5.1, 6.0, and 6.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,9 @@ env:
     - TAG=2.2
     - TAG=2.4
     - TAG=5.0
+    - TAG=5.1
+    - TAG=6.0
+    - TAG=6.1
 
 script:
   - make build

--- a/5.0/test/elasticsearch-5.0.bats
+++ b/5.0/test/elasticsearch-5.0.bats
@@ -8,19 +8,3 @@
 @test "It should have the repository-s3 plugin installed" {
   /elasticsearch/bin/elasticsearch-plugin list | grep -q "repository-s3"
 }
-
-@test "It should fail when --dump is run" {
-  # See: https://github.com/taskrabbit/elasticsearch-dump/issues/259
-  url="http://aptible:password@localhost"
-  run run-database.sh --dump "$url"
-  [[ "$status" -eq 1 ]]
-  [[ "$output" =~ "Not supported" ]]
-}
-
-@test "It should fail when --restore is run" {
-# See: https://github.com/taskrabbit/elasticsearch-dump/issues/259
-  url="http://aptible:password@localhost"
-  run run-database.sh --restore "$url"
-  [[ "$status" -eq 1 ]]
-  [[ "$output" =~ "Not supported" ]]
-}

--- a/5.1/config.mk
+++ b/5.1/config.mk
@@ -1,0 +1,7 @@
+export ES_VERSION = 5.1.1
+export ES_SHA1SUM = 7351cd29ac9c20592d94bde950f513b5c5bb44d3
+export ES_BACKUP_PLUGIN = repository-s3
+export ES_USER = elasticsearch
+export ES_GROUP = elasticsearch
+
+export JAVA_VERSION = 8

--- a/5.1/templates/elasticsearch.yml.template
+++ b/5.1/templates/elasticsearch.yml.template
@@ -1,0 +1,8 @@
+path:
+  data: DATA_DIRECTORY/data
+  logs: DATA_DIRECTORY/log
+  scripts: DATA_DIRECTORY/scripts
+http:
+  cors:
+    enabled: true
+    allow-origin: "/.*/"

--- a/5.1/test/elasticsearch-5.1.bats
+++ b/5.1/test/elasticsearch-5.1.bats
@@ -8,19 +8,3 @@
 @test "It should have the repository-s3 plugin installed" {
   /elasticsearch/bin/elasticsearch-plugin list | grep -q "repository-s3"
 }
-
-@test "It should fail when --dump is run" {
-  # See: https://github.com/taskrabbit/elasticsearch-dump/issues/259
-  url="http://aptible:password@localhost"
-  run run-database.sh --dump "$url"
-  [[ "$status" -eq 1 ]]
-  [[ "$output" =~ "Not supported" ]]
-}
-
-@test "It should fail when --restore is run" {
-# See: https://github.com/taskrabbit/elasticsearch-dump/issues/259
-  url="http://aptible:password@localhost"
-  run run-database.sh --restore "$url"
-  [[ "$status" -eq 1 ]]
-  [[ "$output" =~ "Not supported" ]]
-}

--- a/5.1/test/elasticsearch-5.1.bats
+++ b/5.1/test/elasticsearch-5.1.bats
@@ -1,0 +1,26 @@
+#!/usr/bin/env bats
+
+@test "It should install Elasticsearch 5.1.1" {
+  run elasticsearch-wrapper --version
+  [[ "$output" =~ "Version: 5.1.1"  ]]
+}
+
+@test "It should have the repository-s3 plugin installed" {
+  /elasticsearch/bin/elasticsearch-plugin list | grep -q "repository-s3"
+}
+
+@test "It should fail when --dump is run" {
+  # See: https://github.com/taskrabbit/elasticsearch-dump/issues/259
+  url="http://aptible:password@localhost"
+  run run-database.sh --dump "$url"
+  [[ "$status" -eq 1 ]]
+  [[ "$output" =~ "Not supported" ]]
+}
+
+@test "It should fail when --restore is run" {
+# See: https://github.com/taskrabbit/elasticsearch-dump/issues/259
+  url="http://aptible:password@localhost"
+  run run-database.sh --restore "$url"
+  [[ "$status" -eq 1 ]]
+  [[ "$output" =~ "Not supported" ]]
+}

--- a/6.0/config.mk
+++ b/6.0/config.mk
@@ -1,0 +1,7 @@
+export ES_VERSION = 6.0.1
+export ES_SHA1SUM = fb8400dac5e8853d8f040aaa398ae5e623a2907f
+export ES_BACKUP_PLUGIN = repository-s3
+export ES_USER = elasticsearch
+export ES_GROUP = elasticsearch
+
+export JAVA_VERSION = 8

--- a/6.0/templates/elasticsearch.yml.template
+++ b/6.0/templates/elasticsearch.yml.template
@@ -1,0 +1,7 @@
+path:
+  data: DATA_DIRECTORY/data
+  logs: DATA_DIRECTORY/log
+http:
+  cors:
+    enabled: true
+    allow-origin: "/.*/"

--- a/6.0/test/elasticsearch-6.0.bats
+++ b/6.0/test/elasticsearch-6.0.bats
@@ -8,19 +8,3 @@
 @test "It should have the repository-s3 plugin installed" {
   /elasticsearch/bin/elasticsearch-plugin list | grep -q "repository-s3"
 }
-
-@test "It should fail when --dump is run" {
-  # See: https://github.com/taskrabbit/elasticsearch-dump/issues/259
-  url="http://aptible:password@localhost"
-  run run-database.sh --dump "$url"
-  [[ "$status" -eq 1 ]]
-  [[ "$output" =~ "Not supported" ]]
-}
-
-@test "It should fail when --restore is run" {
-# See: https://github.com/taskrabbit/elasticsearch-dump/issues/259
-  url="http://aptible:password@localhost"
-  run run-database.sh --restore "$url"
-  [[ "$status" -eq 1 ]]
-  [[ "$output" =~ "Not supported" ]]
-}

--- a/6.0/test/elasticsearch-6.0.bats
+++ b/6.0/test/elasticsearch-6.0.bats
@@ -1,0 +1,26 @@
+#!/usr/bin/env bats
+
+@test "It should install Elasticsearch 6.0.1" {
+  run elasticsearch-wrapper --version
+  [[ "$output" =~ "Version: 6.0.1"  ]]
+}
+
+@test "It should have the repository-s3 plugin installed" {
+  /elasticsearch/bin/elasticsearch-plugin list | grep -q "repository-s3"
+}
+
+@test "It should fail when --dump is run" {
+  # See: https://github.com/taskrabbit/elasticsearch-dump/issues/259
+  url="http://aptible:password@localhost"
+  run run-database.sh --dump "$url"
+  [[ "$status" -eq 1 ]]
+  [[ "$output" =~ "Not supported" ]]
+}
+
+@test "It should fail when --restore is run" {
+# See: https://github.com/taskrabbit/elasticsearch-dump/issues/259
+  url="http://aptible:password@localhost"
+  run run-database.sh --restore "$url"
+  [[ "$status" -eq 1 ]]
+  [[ "$output" =~ "Not supported" ]]
+}

--- a/6.1/config.mk
+++ b/6.1/config.mk
@@ -1,0 +1,7 @@
+export ES_VERSION = 6.1.3
+export ES_SHA1SUM = cebe9cc3278440adbce75c580b5c05f684742f56
+export ES_BACKUP_PLUGIN = repository-s3
+export ES_USER = elasticsearch
+export ES_GROUP = elasticsearch
+
+export JAVA_VERSION = 8

--- a/6.1/templates/elasticsearch.yml.template
+++ b/6.1/templates/elasticsearch.yml.template
@@ -1,0 +1,7 @@
+path:
+  data: DATA_DIRECTORY/data
+  logs: DATA_DIRECTORY/log
+http:
+  cors:
+    enabled: true
+    allow-origin: "/.*/"

--- a/6.1/test/elasticsearch-6.1.bats
+++ b/6.1/test/elasticsearch-6.1.bats
@@ -8,19 +8,3 @@
 @test "It should have the repository-s3 plugin installed" {
   /elasticsearch/bin/elasticsearch-plugin list | grep -q "repository-s3"
 }
-
-@test "It should fail when --dump is run" {
-  # See: https://github.com/taskrabbit/elasticsearch-dump/issues/259
-  url="http://aptible:password@localhost"
-  run run-database.sh --dump "$url"
-  [[ "$status" -eq 1 ]]
-  [[ "$output" =~ "Not supported" ]]
-}
-
-@test "It should fail when --restore is run" {
-# See: https://github.com/taskrabbit/elasticsearch-dump/issues/259
-  url="http://aptible:password@localhost"
-  run run-database.sh --restore "$url"
-  [[ "$status" -eq 1 ]]
-  [[ "$output" =~ "Not supported" ]]
-}

--- a/6.1/test/elasticsearch-6.1.bats
+++ b/6.1/test/elasticsearch-6.1.bats
@@ -1,0 +1,26 @@
+#!/usr/bin/env bats
+
+@test "It should install Elasticsearch 6.1.3" {
+  run elasticsearch-wrapper --version
+  [[ "$output" =~ "Version: 6.1.3"  ]]
+}
+
+@test "It should have the repository-s3 plugin installed" {
+  /elasticsearch/bin/elasticsearch-plugin list | grep -q "repository-s3"
+}
+
+@test "It should fail when --dump is run" {
+  # See: https://github.com/taskrabbit/elasticsearch-dump/issues/259
+  url="http://aptible:password@localhost"
+  run run-database.sh --dump "$url"
+  [[ "$status" -eq 1 ]]
+  [[ "$output" =~ "Not supported" ]]
+}
+
+@test "It should fail when --restore is run" {
+# See: https://github.com/taskrabbit/elasticsearch-dump/issues/259
+  url="http://aptible:password@localhost"
+  run run-database.sh --restore "$url"
+  [[ "$status" -eq 1 ]]
+  [[ "$output" =~ "Not supported" ]]
+}

--- a/Dockerfile.erb
+++ b/Dockerfile.erb
@@ -51,10 +51,6 @@ RUN cd /tmp \
  && ln -s "/node-v${NODE_VERSION}-linux-x64/bin/node" /usr/local/bin/ \
  && ln -s "/node-v${NODE_VERSION}-linux-x64/bin/npm" /usr/local/bin/
 
-ENV ELASTICDUMP_VERSION 1.0.3
-RUN npm install -g "elasticdump@${ELASTICDUMP_VERSION}" \
- && ln -s "/node-v${NODE_VERSION}-linux-x64/bin/elasticdump" /usr/local/bin/
-
 
 # Configuration templates
 ADD templates/nginx.conf.template /etc/nginx/nginx.conf.template

--- a/README.md
+++ b/README.md
@@ -20,7 +20,10 @@ The first command sets up a data container named `data` which will hold the conf
 
 ## Available Tags
 
-* `latest`: Currently Elasticsearch 5.0.2
+* `latest`: Currently Elasticsearch 5.0
+* `6.1`: Elasticsearch 6.1.3
+* `6.0`: Elasticsearch 6.0.1
+* `5.1`: Elasticsearch 5.1.1
 * `5.0`: Elasticsearch 5.0.2
 * `2.4`: Elasticsearch 2.4.5
 * `2.2`: Elasticsearch 2.2.1

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ The first command sets up a data container named `data` which will hold the conf
 
 ## Available Tags
 
-* `latest`: Currently Elasticsearch 5.0
+* `latest`: Currently Elasticsearch 6.1
 * `6.1`: Elasticsearch 6.1.3
 * `6.0`: Elasticsearch 6.0.1
 * `5.1`: Elasticsearch 5.1.1

--- a/bin/elasticsearch-wrapper
+++ b/bin/elasticsearch-wrapper
@@ -2,6 +2,12 @@
 set -o errexit
 set -o nounset
 
+# ES no longer allows AWS creds to be be passed via request when creating
+# a backup respository, but we'd rather keep doing that, anyways.
+if dpkg --compare-versions "$ES_VERSION" ge 6; then
+  export ES_JAVA_OPTS="-Des.allow_insecure_settings=true ${ES_JAVA_OPTS:-}"
+fi
+
 if [[ -n "${ES_HEAP_SIZE:-}" ]]; then
   # If we have an ENV var that sets ES_HEAP_SIZE, then we use that.
   echo "ES_HEAP_SIZE was forced to ${ES_HEAP_SIZE} via configuration!"

--- a/bin/elasticsearch-wrapper
+++ b/bin/elasticsearch-wrapper
@@ -3,7 +3,9 @@ set -o errexit
 set -o nounset
 
 # ES no longer allows AWS creds to be be passed via request when creating
-# a backup respository, but we'd rather keep doing that, anyways.
+# a backup respository, but we need to continue doing so since the new way:
+# * requires shell access to modify the filesystem
+# * cannot be updated at runtime
 if dpkg --compare-versions "$ES_VERSION" ge 6; then
   export ES_JAVA_OPTS="-Des.allow_insecure_settings=true ${ES_JAVA_OPTS:-}"
 fi

--- a/bin/run-database.sh
+++ b/bin/run-database.sh
@@ -64,28 +64,12 @@ elif [[ "$1" == "--client" ]]; then
   echo "This image does not support the --client option. Use curl instead." && exit 1
 
 elif [[ "$1" == "--dump" ]]; then
-  [ -z "$2" ] && echo "docker run aptible/elasticsearch --dump https://... > dump.es" && exit
-
-  if dpkg --compare-versions "$ES_VERSION" ge 5; then
-    echo "Not supported for Elasticsearch ${ES_VERSION}"
-    exit 1
-  fi
-
-  parse_url "$2"
-  # shellcheck disable=SC2154
-  elasticdump --all=true --input="${protocol:-"https://"}${user}:${password}@${host}:${port:-80}" '--output=$'
+  echo "Not supported"
+  exit 1
 
 elif [[ "$1" == "--restore" ]]; then
-  [ -z "$2" ] && echo "docker run -i aptible/elasticsearch --restore https://... < dump.es" && exit
-
-  if dpkg --compare-versions "$ES_VERSION" ge 5; then
-    echo "Not supported for Elasticsearch ${ES_VERSION}"
-    exit 1
-  fi
-
-  parse_url "$2"
-  # shellcheck disable=SC2154
-  elasticdump --bulk=true '--input=$' --output="${protocol:-"https://"}${user}:${password}@${host}:${port:-80}"
+  echo "Not supported"
+  exit 1
 
 else
   echo "Unrecognized command: $1"

--- a/latest.mk
+++ b/latest.mk
@@ -1,1 +1,1 @@
-LATEST_TAG = 5.0
+LATEST_TAG = 6.1

--- a/test-backup.sh
+++ b/test-backup.sh
@@ -23,7 +23,6 @@ json=$(cat << EOF
     "base_path": "${S3_BUCKET_BASE_PATH}",
     "access_key": "${AWS_ACCESS_KEY_ID}",
     "secret_key": "${AWS_SECRET_ACCESS_KEY}",
-    "region": "${S3_REGION}",
     "protocol": "https",
     "server_side_encryption": true
   }
@@ -38,8 +37,8 @@ function cleanup {
 
 function wait_for_s3 {
 
-  for _ in $(seq 1 60); do
-    if docker exec "$DB_CONTAINER" curl -w "\n" -sS -XPUT "${REPOSITORY_URL}" -d "$json" | grep '{\"acknowledged\":true}'; then
+  for _ in $(seq 1 30); do
+    if docker exec "$DB_CONTAINER" curl -w "\n" -H'Content-Type: application/json' -sS -XPUT "${REPOSITORY_URL}" -d "$json" | grep '{\"acknowledged\":true}'; then
       echo "S3 backup succeeded."
       return 0
     fi

--- a/test-plugin.sh
+++ b/test-plugin.sh
@@ -6,7 +6,13 @@ IMG="$1"
 
 DB_CONTAINER="elastic"
 DATA_CONTAINER="${DB_CONTAINER}-data"
-PLUGINS="mapper-attachments analysis-phonetic"
+
+if dpkg --compare-versions "$ES_VERSION" ge 5; then
+  PLUGINS="ingest-attachment analysis-phonetic"
+else
+  PLUGINS="mapper-attachments analysis-phonetic"
+fi
+
 
 function cleanup {
   echo "Cleaning up"

--- a/test/elasticsearch-all.bats
+++ b/test/elasticsearch-all.bats
@@ -177,39 +177,6 @@ teardown() {
   [[ "$output" =~ "-Xms512m -Xmx512m" ]]
 }
 
-@test "It should support compatible --dump and --restore commands" {
-  if dpkg --compare-versions "$ES_VERSION" ge 5; then
-    skip "Not supported yet on ${ES_VERSION}"
-  fi
-
-  url="http://aptible:password@localhost"
-  dump="${BATS_TEST_DIRNAME}/dump-file"
-
-  initialize_elasticsearch
-  wait_for_elasticsearch
-
-  curl -s -XPUT "http://localhost:9200/tests/test/1" -d'{
-    "testId": 1,
-    "testValue": "TEST_VALUE"
-  }'
-  curl -s "http://localhost:9200/tests/test/1" | grep "TEST_VALUE"
-
-  # We have to repeat the dump a few times, because it originally
-  # comes out empty (most likely a question of timing).
-  until [[ -s "$dump" ]]; do
-    run-database.sh --dump "$url" > "$dump"
-  done
-
-  teardown
-  setup
-
-  initialize_elasticsearch
-  wait_for_elasticsearch
-
-  run-database.sh --restore "$url" < "$dump"
-  curl -s "http://localhost:9200/tests/test/1" | grep "TEST_VALUE"
-}
-
 @test "It should disable multicast cluster discovery in config" {
   if dpkg --compare-versions "$ES_VERSION" ge 5; then
     skip "Not needed on ${ES_VERSION}"


### PR DESCRIPTION
Changes required for 6.0 : 

File scripts have been removed. Instead, use stored scripts. The associated setting path.scripts has also been removed. [Link](https://www.elastic.co/guide/en/elasticsearch/reference/6.0/breaking_60_scripting_changes.html#_file_scripts_removed). Updated `elasticsearch.yml.template` to remove setting.

In previous versions of Elasticsearch, the configuration file was allowed to contain duplicate key, this is no longer permitted. Instead, this must be specified in a single key. [Link](https://www.elastic.co/guide/en/elasticsearch/reference/6.0/breaking_60_settings_changes.html#_duplicate_keys_in_configuration_file). Updated `elasticsearch.yml.template` to combine multiple 'http:cors:' options.

Sets `allow_insecure_settings` for 6.0 and 6.1 to allow the use of AWS credentials via repository requests (IE S 3 backup. Would otherwise require using the new (CLI only) keystore : [link](https://www.elastic.co/guide/en/elasticsearch/plugins/current/repository-s3-client.html)

The mapper attachments plugin has been deprecated in elasticsearch 5.0 and the ingest attachment plugin is used now instead instead. [Link](	https://www.elastic.co/guide/en/elasticsearch/reference/6.0/breaking_60_plugins_changes.html#_mapper_attachments_plugin). Updated `test-plugin.sh` to try the correct plugin based upon the ES version.

Dropping --dump/--restore entirely; the new versions do support ES>5, but don't support --all=true or --bulk=true. The new `multielasticdump` only takes a source/destination of a folder (ie in container) -- we had been relying on output to STDOUT and redirecting to a file on the host, which is not available for ES >= 5.

Specifying region of an S3 backup repository has been removed. PR to update the s3 backup App is here : https://github.com/aptible/elasticsearch-logstash-s3-backup/pull/18

Kibana images will need to be updated : https://github.com/aptible/docker-kibana/pull/26

Be aware that in 6.0+ REST requests that include a body must also provide the correct content-type: https://www.elastic.co/blog/strict-content-type-checking-for-elasticsearch-rest-requests