### PR TITLE
Add Elasticsearch 5.6 and 6.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,8 +15,10 @@ env:
     - TAG=2.4
     - TAG=5.0
     - TAG=5.1
+    - TAG=5.6
     - TAG=6.0
     - TAG=6.1
+    - TAG=6.2
 
 script:
   - make build

--- a/5.6/config.mk
+++ b/5.6/config.mk
@@ -1,0 +1,7 @@
+export ES_VERSION = 5.6.8
+export ES_SHA1SUM = 571dc6c89e9598dd2971c99776af3777160c92fb
+export ES_BACKUP_PLUGIN = repository-s3
+export ES_USER = elasticsearch
+export ES_GROUP = elasticsearch
+
+export JAVA_VERSION = 8

--- a/5.6/templates/elasticsearch.yml.template
+++ b/5.6/templates/elasticsearch.yml.template
@@ -1,0 +1,8 @@
+path:
+  data: DATA_DIRECTORY/data
+  logs: DATA_DIRECTORY/log
+  scripts: DATA_DIRECTORY/scripts
+http:
+  cors:
+    enabled: true
+    allow-origin: "/.*/"

--- a/5.6/test/elasticsearch-5.6.bats
+++ b/5.6/test/elasticsearch-5.6.bats
@@ -1,0 +1,10 @@
+#!/usr/bin/env bats
+
+@test "It should install Elasticsearch 5.6.8" {
+  run elasticsearch-wrapper --version
+  [[ "$output" =~ "Version: 5.6.8"  ]]
+}
+
+@test "It should have the repository-s3 plugin installed" {
+  /elasticsearch/bin/elasticsearch-plugin list | grep -q "repository-s3"
+}

--- a/6.2/config.mk
+++ b/6.2/config.mk
@@ -1,0 +1,7 @@
+export ES_VERSION = 6.2.2
+export ES_SHA1SUM = b0c2c4f98b7bfe97ddc1be53b121ce08e488442f
+export ES_BACKUP_PLUGIN = repository-s3
+export ES_USER = elasticsearch
+export ES_GROUP = elasticsearch
+
+export JAVA_VERSION = 8

--- a/6.2/templates/elasticsearch.yml.template
+++ b/6.2/templates/elasticsearch.yml.template
@@ -1,0 +1,7 @@
+path:
+  data: DATA_DIRECTORY/data
+  logs: DATA_DIRECTORY/log
+http:
+  cors:
+    enabled: true
+    allow-origin: "/.*/"

--- a/6.2/test/elasticsearch-6.2.bats
+++ b/6.2/test/elasticsearch-6.2.bats
@@ -1,0 +1,10 @@
+#!/usr/bin/env bats
+
+@test "It should install Elasticsearch 6.2.2" {
+  run elasticsearch-wrapper --version
+  [[ "$output" =~ "Version: 6.2.2"  ]]
+}
+
+@test "It should have the repository-s3 plugin installed" {
+  /elasticsearch/bin/elasticsearch-plugin list | grep -q "repository-s3"
+}

--- a/README.md
+++ b/README.md
@@ -20,9 +20,11 @@ The first command sets up a data container named `data` which will hold the conf
 
 ## Available Tags
 
-* `latest`: Currently Elasticsearch 6.1
+* `latest`: Currently Elasticsearch 6.2
+* `6.2`: Elasticsearch 6.2.2
 * `6.1`: Elasticsearch 6.1.3
 * `6.0`: Elasticsearch 6.0.1
+* `5.6`: Elasticsearch 5.6.8
 * `5.1`: Elasticsearch 5.1.1
 * `5.0`: Elasticsearch 5.0.2
 * `2.4`: Elasticsearch 2.4.5

--- a/latest.mk
+++ b/latest.mk
@@ -1,1 +1,1 @@
-LATEST_TAG = 6.1
+LATEST_TAG = 6.2


### PR DESCRIPTION
Replaces https://github.com/aptible/docker-elasticsearch/pull/41