### PR TITLE
Initialize keystore on ES boot

### DIFF
--- a/bin/elasticsearch-wrapper
+++ b/bin/elasticsearch-wrapper
@@ -40,6 +40,18 @@ if [[ -n "${ES_HEAP_SIZE:-}" ]]; then
   fi
 fi
 
+# If this version of Elasticsearch supports the keystore, create an emtpy
+# keystore and give the Elasticsearch user access. We don't use it to store
+# anything, but it needs to be accessible or e.g. the X-Pack won't boot.
+KEYSTORE_MANAGER="/elasticsearch/bin/elasticsearch-keystore"
+KEYSTORE_FILE="/elasticsearch/config/elasticsearch.keystore"
+if [[ -x "$KEYSTORE_MANAGER" ]]; then
+  if [[ ! -f "$KEYSTORE_FILE" ]]; then
+    "$KEYSTORE_MANAGER" create
+  fi
+  chown "${ES_USER}:${ES_GROUP}" "$KEYSTORE_FILE"
+fi
+
 # Install any user specified plugins
 
 if [[ -n "${ES_PLUGINS:-}" ]]; then

--- a/test-xpack.sh
+++ b/test-xpack.sh
@@ -36,7 +36,7 @@ function get_license_uid {
 trap cleanup EXIT
 cleanup
 
-if [[ ! "$TAG" =~ ^5 ]]; then
+if [[ "$TAG" =~ ^1 ]] || [[ "$TAG" =~ ^2 ]]; then
   echo "Not running x-pack test on ${TAG}"
   exit 0
 fi
@@ -87,4 +87,9 @@ wait_for_xpack
 if [[ "$uid" != "$(get_license_uid)" ]]; then
   echo "License UID changed after recreate"
   exit 1
+fi
+
+if [[ ! "$TAG" =~ ^5 ]]; then
+  echo "Checking keystore was not used"
+  ! docker exec -it "$DB_CONTAINER" /elasticsearch/bin/elasticsearch-keystore list | grep -v keystore.seed
 fi


### PR DESCRIPTION
Installing the x-pack creates a keystore, but the keystore is not
actually used.

---

cc @fancyremarker 