### PR TITLE
Add 6.6, version bumps.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,6 +22,7 @@ env:
     - TAG=6.3
     - TAG=6.4
     - TAG=6.5
+    - TAG=6.6
 
 script:
   - make build

--- a/5.6/config.mk
+++ b/5.6/config.mk
@@ -1,5 +1,5 @@
-export ES_VERSION = 5.6.13
-export ES_SHA1SUM = 4c8ed27d362d76b5bdc52327721b44bb55215205
+export ES_VERSION = 5.6.15
+export ES_SHA1SUM = 42d2519fd7d47e5b0bbef05d402ff0f66fbbe2ca
 export ES_BACKUP_PLUGIN = repository-s3
 export ES_USER = elasticsearch
 export ES_GROUP = elasticsearch

--- a/6.6/config.mk
+++ b/6.6/config.mk
@@ -1,5 +1,5 @@
-export ES_VERSION = 6.5.4
-export ES_SHA1SUM = f89d5796108b393cff87a0c0325065bc112b01ad
+export ES_VERSION = 6.6.1
+export ES_SHA1SUM = 43f304921fb46bc64cc23b522c2faa391074c731
 export ES_BACKUP_PLUGIN = repository-s3
 export ES_USER = elasticsearch
 export ES_GROUP = elasticsearch

--- a/6.6/templates/elasticsearch.yml.template
+++ b/6.6/templates/elasticsearch.yml.template
@@ -1,0 +1,7 @@
+path:
+  data: DATA_DIRECTORY/data
+  logs: DATA_DIRECTORY/log
+http:
+  cors:
+    enabled: true
+    allow-origin: "/.*/"

--- a/6.6/test/elasticsearch-6.6.bats
+++ b/6.6/test/elasticsearch-6.6.bats
@@ -1,0 +1,5 @@
+#!/usr/bin/env bats
+
+@test "It should have the repository-s3 plugin installed" {
+  /elasticsearch/bin/elasticsearch-plugin list | grep -q "repository-s3"
+}

--- a/README.md
+++ b/README.md
@@ -20,7 +20,8 @@ The first command sets up a data container named `data` which will hold the conf
 
 ## Available Tags
 
-* `latest`: Currently Elasticsearch 6.5
+* `latest`: Currently Elasticsearch 6.6
+* `6.6
 * `6.5`
 * `6.4`
 * `6.3`

--- a/latest.mk
+++ b/latest.mk
@@ -1,1 +1,1 @@
-LATEST_TAG = 6.5
+LATEST_TAG = 6.6


### PR DESCRIPTION
Adds support for 6.6, no breaking changes here that should give pause to use for logging.

https://www.elastic.co/guide/en/elasticsearch/reference/6.6/release-notes-6.6.1.html

Other minor update:
https://www.elastic.co/guide/en/elasticsearch/reference/6.5/release-notes-6.5.4.html

And finally, this must be to keep version parity with Kibana, which includes security fixes in 5.6.15
>There are no changes for [Elasticsearch] 5.6.15
https://www.elastic.co/guide/en/elasticsearch/reference/5.6/release-notes-5.6.15.html