### PR TITLE
Disable x-pack security on ES 6.3+

### DIFF
--- a/bin/elasticsearch-wrapper
+++ b/bin/elasticsearch-wrapper
@@ -76,6 +76,10 @@ if dpkg --compare-versions "$ES_VERSION" lt 6.3; then
     fi
     echo "xpack.security.enabled: false" >> /elasticsearch/config/elasticsearch.yml
   fi
+else
+  # ES_VERSION gte 6.3 - those where we dont' need to explicitly install x-pack ourselves
+  # In case customer adds a paid license, we need to be sure this is disabled, too.
+  echo "xpack.security.enabled: false" >> /elasticsearch/config/elasticsearch.yml
 fi
 
 exec sudo -HE -u "$ES_USER" /elasticsearch/bin/elasticsearch "$@"


### PR DESCRIPTION
We already disable x-pack security when we explicitly install x-pack plugin, but we also need to disable security when x-pack is already shipped with ES (versions 6.3+).